### PR TITLE
docs: Fix simple typo, reporing -> reporting

### DIFF
--- a/guitarfan/static/FineUploader/jquery.fineuploader-3.7.1.js
+++ b/guitarfan/static/FineUploader/jquery.fineuploader-3.7.1.js
@@ -1865,7 +1865,7 @@ qq.FineUploaderBasic.prototype = {
             this._uploadData.setStatus(id, qq.status.DELETE_FAILED);
             this.log("Delete request for '" + name + "' has failed.", "error");
 
-            // For error reporing, we only have accesss to the response status if this is not
+            // For error reporting, we only have accesss to the response status if this is not
             // an `XDomainRequest`.
             if (xhrOrXdr.withCredentials === undefined) {
                 this._options.callbacks.onError(id, name, "Delete request failed", xhrOrXdr);


### PR DESCRIPTION
There is a small typo in guitarfan/static/FineUploader/jquery.fineuploader-3.7.1.js.

Should read `reporting` rather than `reporing`.

